### PR TITLE
Adding blurbs about partuuid process and IDs

### DIFF
--- a/docs/linux-docs/kubos-linux-on-bbb.rst
+++ b/docs/linux-docs/kubos-linux-on-bbb.rst
@@ -45,6 +45,10 @@ U-Boot
 This board utilizes U-Boot's SPL feature. A small boot file called "MLO" is
 run and that file then loads the main U-Boot image into SDRAM.
 
+The main U-Boot image iterates through the `boot_targets` variable to attempt 
+to boot from an available MMC device. The partuuid of the first successful
+device is passed off to Linux to be used to mount the root filesystem. 
+
 KubOS Linux Build Process
 -------------------------
 
@@ -144,7 +148,8 @@ The relevant files are:
 -  beaglebone-black.dtb - The Device Tree Binary that Linux uses to configure itself
    for the Beaglebone Black board
 -  rootfs.tar - The root file system. Contains BusyBox and other libraries
--  kubos-linux.img - The complete KubOS Linux SD card image
+-  kubos-linux.img - The complete KubOS Linux SD card image. It has a disk
+    signature of 0x4B4C4E58 ("KLNX").
 
 Changing the Output Toolchain Directory (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -172,6 +177,8 @@ Then, from the `kubos-linux-build/tools` folder, run the ``format-aux.img`` scri
 This will create a new SD card image, `aux-sd.img`, with two partitions:
 - An upgrade partition containing `kpack-base.itb`
 - A user data partition
+
+The image's disk signature will be 0x41555820 ("AUX ").
 
 There are two parameters which may be specified:
 

--- a/docs/linux-docs/kubos-linux-on-mbm2.rst
+++ b/docs/linux-docs/kubos-linux-on-mbm2.rst
@@ -45,6 +45,10 @@ U-Boot
 This board utilizes U-Boot's SPL feature. A small boot file called "MLO" is
 run and that file then loads the main U-Boot image into SDRAM.
 
+The main U-Boot image iterates through the `boot_targets` variable to attempt 
+to boot from an available MMC device. The partuuid of the first successful
+device is passed off to Linux to be used to mount the root filesystem. 
+
 KubOS Linux Build Process
 -------------------------
 
@@ -144,7 +148,8 @@ The relevant files are:
 -  pumpkin-mbm2.dtb - The Device Tree Binary that Linux uses to configure itself
    for the Pumpkin MBM2 board
 -  rootfs.tar - The root file system. Contains BusyBox and other libraries
--  kubos-linux.img - The complete KubOS Linux SD card image
+-  kubos-linux.img - The complete KubOS Linux SD card image. It has a disk
+    signature of 0x4B4C4E58 ("KLNX").
 
 Changing the Output Toolchain Directory (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -172,6 +177,8 @@ Then, from the `kubos-linux-build/tools` folder, run the ``format-aux.img`` scri
 This will create a new SD card image, `aux-sd.img`, with two partitions:
 - An upgrade partition containing `kpack-base.itb`
 - A user data partition
+
+The image's disk signature will be 0x41555820 ("AUX ").
 
 There are two parameters which may be specified:
 


### PR DESCRIPTION
PRs kubos/kubos-linux-build#83 and kubos/uboot#22 change the way that the BBB and MBM2 boot up. I was going to change the relevant documentation, but apparently that was never documented...

So instead I'm adding a new blurb about how U-Boot gets the boot device for Linux and then the new disk signatures that are used to generate the partuuids.